### PR TITLE
Refactor current query terms

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,16 @@
 {
+  "parser": "babel-eslint",
   "extends": "airbnb",
+  "env": {
+      "browser": true,
+      "node": true,
+      "mocha": true,
+      "jquery": true
+  },
   "rules": {
-    "comma-dangle": 0
+      "indent": [2, 2],
+      "no-console": 0,
+      "no-alert": 0,
+      "comma-dangle": 0
   }
 }

--- a/public/css/customFonts.css
+++ b/public/css/customFonts.css
@@ -29,15 +29,15 @@ i {
     content: "\1f44c";
 }
 
-#searchKeyword::-webkit-input-placeholder {
+#addSearchTerm::-webkit-input-placeholder {
     color:    #999;
 }
-#searchKeyword:-moz-placeholder {
+#addSearchTerm:-moz-placeholder {
     color:    #999;
 }
-#searchKeyword::-moz-placeholder {
+#addSearchTerm::-moz-placeholder {
     color:    #999;
 }
-#searchKeyword:-ms-input-placeholder {
+#addSearchTerm:-ms-input-placeholder {
     color:    #999;
 }  

--- a/src/client/search/AddSearchTerm.js
+++ b/src/client/search/AddSearchTerm.js
@@ -1,0 +1,36 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { addSearchTerm } from './SearchActions';
+
+let AddSearchTerm = ({ dispatch, addSerchTermRef }) => {
+  const keywordSearchStyle = {
+    display:'none',
+    paddingLeft:20,
+    paddingTop:10,
+    marginTop:10,
+    borderTop:1,
+    borderTop: '2px dashed #D3D5D8',
+  };
+  return (
+    <div className="ui fluid big transparent input"
+      style={keywordSearchStyle}
+      id="searchTermContainer">
+      <input id='addSearchTerm' type="text"
+        placeholder="Search a keyword or hashtag"
+        onBlur={(e) => {
+          $('#searchTermContainer').slideUp('fast');
+        }}
+        onKeyDown={(e) => {
+          if (e.keyCode == 13) {
+            dispatch(addSearchTerm(nextSearchTermId++, e.target.value));
+            e.target.value = '';
+          }
+        }}/>
+      <i className="link remove circle icon"></i>
+    </div>
+  );
+};
+
+AddSearchTerm = connect()(AddSearchTerm);
+
+export default AddSearchTerm;

--- a/src/client/search/AddSearchTerm.js
+++ b/src/client/search/AddSearchTerm.js
@@ -2,30 +2,33 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { addSearchTerm } from './SearchActions';
 
-let AddSearchTerm = ({ dispatch, addSerchTermRef }) => {
+let nextSearchTermId = 0;
+
+let AddSearchTerm = ({ dispatch }) => {
   const keywordSearchStyle = {
-    display:'none',
-    paddingLeft:20,
-    paddingTop:10,
-    marginTop:10,
-    borderTop:1,
+    display: 'none',
+    paddingLeft: 20,
+    paddingTop: 10,
+    marginTop: 10,
     borderTop: '2px dashed #D3D5D8',
   };
   return (
     <div className="ui fluid big transparent input"
       style={keywordSearchStyle}
-      id="searchTermContainer">
-      <input id='addSearchTerm' type="text"
+      id="searchTermContainer"
+    >
+      <input id="addSearchTerm" type="text"
         placeholder="Search a keyword or hashtag"
-        onBlur={(e) => {
+        onBlur={() => {
           $('#searchTermContainer').slideUp('fast');
         }}
         onKeyDown={(e) => {
-          if (e.keyCode == 13) {
+          if (e.keyCode === 13) {
             dispatch(addSearchTerm(nextSearchTermId++, e.target.value));
             e.target.value = '';
           }
-        }}/>
+        }}
+      />
       <i className="link remove circle icon"></i>
     </div>
   );

--- a/src/client/search/CurrentQueryTerms.js
+++ b/src/client/search/CurrentQueryTerms.js
@@ -2,11 +2,10 @@ import React, { Component } from 'react';
 import SearchTermsList from './SearchTermsList';
 import AddSearchTerm from './AddSearchTerm';
 
-let nextSearchTermId = 0;
-
 const CurrentQueryTerms = () => {
   const showAddSearchTerm = () => {
-    //searchTermContainer and addSearchTerm are in ./AddSearchTerm
+    // searchTermContainer and addSearchTerm are in ./AddSearchTerm
+    // bad practise, should use react refs but using html id for simplicity
     if ($('#searchTermContainer').is(':hidden')) {
       $('#searchTermContainer').slideDown('fast', () => {
         $('#addSearchTerm').focus();
@@ -19,9 +18,8 @@ const CurrentQueryTerms = () => {
   return (
     <div className="row ui raised segment">
       <div style={{ cursor: 'text' }}>
-        <SearchTermsList showSearchTerm={showAddSearchTerm}/>
-
-        <AddSearchTerm addSerchTermRef={node => searchTermRef = node}/>
+        <SearchTermsList showSearchTerm={showAddSearchTerm} />
+        <AddSearchTerm />
       </div>
     </div>
   );

--- a/src/client/search/CurrentQueryTerms.js
+++ b/src/client/search/CurrentQueryTerms.js
@@ -1,64 +1,30 @@
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { addSearchTerm } from './SearchActions';
 import SearchTermsList from './SearchTermsList';
+import AddSearchTerm from './AddSearchTerm';
 
 let nextSearchTermId = 0;
+
 const CurrentQueryTerms = () => {
-  let showSearchkeyword = false;
-  let containerRef;
+  const showAddSearchTerm = () => {
+    //searchTermContainer and addSearchTerm are in ./AddSearchTerm
+    if ($('#searchTermContainer').is(':hidden')) {
+      $('#searchTermContainer').slideDown('fast', () => {
+        $('#addSearchTerm').focus();
+      });
+    } else {
+      $('#searchTermContainer').slideUp('fast');
+    }
+  };
+
   return (
     <div className="row ui raised segment">
-      <div style={{ cursor: 'text' }} onClick={() => {
-        showSearchkeyword = !showSearchkeyword;
-        if (showSearchkeyword) {
-          $(containerRef).slideDown('fast', () => {
-            containerRef.focus();
-          });
-        } else {
-          $(containerRef).slideUp('fast');
-        }
-			}}>
-        <SearchTermsList />
+      <div style={{ cursor: 'text' }}>
+        <SearchTermsList showSearchTerm={showAddSearchTerm}/>
 
-        <AddSearchTerm addSearchTermRef={node => containerRef = node}/>
+        <AddSearchTerm addSerchTermRef={node => searchTermRef = node}/>
       </div>
     </div>
   );
 };
-
-let AddSearchTerm = ({ dispatch, addSearchTermRef }) => {
-  const keywordSearchStyle = {
-    display:'none',
-    paddingLeft:20,
-    paddingTop:10,
-    marginTop:10,
-    borderTop:1,
-    borderTop: '2px dashed #D3D5D8',
-  }
-  return(
-    <div className="ui fluid big transparent input"
-      style={keywordSearchStyle}
-      ref={addSearchTermRef}
-      onClick={(e) => {
-        e.stopPropagation();
-      }}>
-      <input type="text" placeholder="Search a keyword or hashtag"
-        onBlur={() => {
-          $(addSearchTermRef).slideUp('fast');
-        }}
-        onKeyDown={(e) => {
-          console.log(e);
-          if (e.keyCode == 13) {
-            dispatch(addSearchTerm(nextSearchTermId++, searchKeyword.value));
-            searchKeyword.value = '';
-          }
-        }}/>
-      <i className="link remove circle icon"></i>
-    </div>
-  );
-};
-
-AddSearchTerm = connect()(AddSearchTerm);
 
 export default CurrentQueryTerms;

--- a/src/client/search/CurrentQueryTerms.js
+++ b/src/client/search/CurrentQueryTerms.js
@@ -4,53 +4,61 @@ import { addSearchTerm } from './SearchActions';
 import SearchTermsList from './SearchTermsList';
 
 let nextSearchTermId = 0;
-let CurrentQueryTerms = ({ dispatch }) => {
+const CurrentQueryTerms = () => {
   let showSearchkeyword = false;
-  let searchKeyword;
+  let containerRef;
   return (
     <div className="row ui raised segment">
       <div style={{ cursor: 'text' }} onClick={() => {
         showSearchkeyword = !showSearchkeyword;
         if (showSearchkeyword) {
-          $('#searchKeywordContainer').slideDown('fast', () => {
-            searchKeyword.focus();
+          $(containerRef).slideDown('fast', () => {
+            containerRef.focus();
           });
+        } else {
+          $(containerRef).slideUp('fast');
         }
 			}}>
         <SearchTermsList />
 
-        <div id="searchKeywordContainer" className="ui fluid big transparent input"
-             style={{
-            display:'none',
-            paddingLeft:20,
-            paddingTop:10,
-            marginTop:10,
-            borderTop:1,
-            borderTop: '2px dashed #D3D5D8',
-			  }}>
-          <input id="searchKeyword" type="text" placeholder="Search a keyword or hashtag"
-                 ref={(node) => {
-              searchKeyword = node;
-						}}
-                 onBlur={() => {
-              $('#searchKeywordContainer').slideUp('fast', () => {
-                showSearchkeyword = false;
-              });
-						}}
-
-                 onKeyDown={(e) => {
-              if (e.keyCode == 13) {
-                dispatch(addSearchTerm(nextSearchTermId++, searchKeyword.value));
-                searchKeyword.value = '';
-              }
-						}}/>
-          <i className="link remove circle icon"></i>
-        </div>
+        <AddSearchTerm addSearchTermRef={node => containerRef = node}/>
       </div>
     </div>
   );
 };
 
-CurrentQueryTerms = connect()(CurrentQueryTerms);
+let AddSearchTerm = ({ dispatch, addSearchTermRef }) => {
+  const keywordSearchStyle = {
+    display:'none',
+    paddingLeft:20,
+    paddingTop:10,
+    marginTop:10,
+    borderTop:1,
+    borderTop: '2px dashed #D3D5D8',
+  }
+  return(
+    <div className="ui fluid big transparent input"
+      style={keywordSearchStyle}
+      ref={addSearchTermRef}
+      onClick={(e) => {
+        e.stopPropagation();
+      }}>
+      <input type="text" placeholder="Search a keyword or hashtag"
+        onBlur={() => {
+          $(addSearchTermRef).slideUp('fast');
+        }}
+        onKeyDown={(e) => {
+          console.log(e);
+          if (e.keyCode == 13) {
+            dispatch(addSearchTerm(nextSearchTermId++, searchKeyword.value));
+            searchKeyword.value = '';
+          }
+        }}/>
+      <i className="link remove circle icon"></i>
+    </div>
+  );
+};
+
+AddSearchTerm = connect()(AddSearchTerm);
 
 export default CurrentQueryTerms;

--- a/src/client/search/SearchTermsList.js
+++ b/src/client/search/SearchTermsList.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
-const TermsList = ({ searchTerms }) => {
+const TermsList = ({ searchTerms, showSearchTerm }) => {
   return (
-    <div>
+    <div onClick={showSearchTerm}>
       <i className="icon search"></i>
       {searchTerms.map(term => {
         return (

--- a/src/client/search/SearchTermsReducer.spec.js
+++ b/src/client/search/SearchTermsReducer.spec.js
@@ -18,7 +18,7 @@ describe('#SearchTermsReducer', () => {
       query: 'Football',
       paramTypes: ['hashtag'],
       source: 'twitter',
-    },];
+    }, ];
 
     deepFreeze(stateBefore);
     deepFreeze(action);
@@ -32,7 +32,7 @@ describe('#SearchTermsReducer', () => {
       query: 'Football',
       paramTypes: ['mention'],
       source: 'twitter',
-    },];
+    }, ];
     const action = {
       type: 'ADD_SEARCH_TERM',
       id: 1,


### PR DESCRIPTION
-Changed #searchKeyword css to #addSearchTerm to be consistent with name of component
-Extracted AddSearchTerm into its own component
-Using ids with jquery instead of react refs since it was the way to achieve the onclick and focus in the least amount of code and also so selecting the container and addsearchterm is consistently using ids instead of one using refs and the other using id selector 

@Winwardo ready to be checked and merged if you're happy with it.
