### PR TITLE
Updating all modules to their latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,12 +37,13 @@
     "react-redux": "^4.4.1",
     "redux": "^3.3.1",
     "redux-thunk": "^2.0.1",
-    "style-loader": "^0.13.0"
+    "style-loader": "^0.13.0",
+    "twit": "^2.2.2"
   },
   "devDependencies": {
     "babel-cli": "^6.6.4",
     "babel-core": "^6.7.2",
-    "babel-eslint": "^5.0.0",
+    "babel-eslint": "^6.0.0",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-react": "^6.5.0",
@@ -63,7 +64,6 @@
     "mocha-lcov-reporter": "^1.2.0",
     "nodemon": "^1.9.1",
     "redbox-react": "^1.2.2",
-    "twit": "^2.2.2",
     "webpack": "^1.12.14",
     "webpack-dev-middleware": "^1.5.1",
     "webpack-hot-middleware": "^2.10.0"

--- a/package.json
+++ b/package.json
@@ -24,25 +24,25 @@
   "license": "All copyright retained.",
   "homepage": "https://github.com/Winwardo/solid-octo-disco",
   "dependencies": {
-    "babel-polyfill": "^6.7.2",
+    "babel-polyfill": "^6.7.4",
     "body-parser": "^1.15.0",
     "cross-env": "^1.0.7",
     "express": "^4.13.4",
     "isomorphic-fetch": "^2.2.1",
     "js-builder-decorator": "^0.1.3",
-    "moment": "^2.11.2",
+    "moment": "^2.12.0",
     "orientjs": "^2.1.11",
-    "react": "^0.14.7",
-    "react-dom": "^0.14.7",
+    "react": "^0.14.8",
+    "react-dom": "^0.14.8",
     "react-redux": "^4.4.1",
     "redux": "^3.3.1",
     "redux-thunk": "^2.0.1",
-    "style-loader": "^0.13.0",
-    "twit": "^2.2.2"
+    "style-loader": "^0.13.1",
+    "twit": "^2.2.3"
   },
   "devDependencies": {
-    "babel-cli": "^6.6.4",
-    "babel-core": "^6.7.2",
+    "babel-cli": "^6.6.5",
+    "babel-core": "^6.7.4",
     "babel-eslint": "^6.0.0",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.5.0",
@@ -51,8 +51,8 @@
     "chai": "^3.5.0",
     "codacy-coverage": "^1.1.3",
     "deep-freeze": "0.0.1",
-    "eslint": "^2.4.0",
-    "eslint-config-airbnb": "^6.0.2",
+    "eslint": "^2.5.3",
+    "eslint-config-airbnb": "^6.2.0",
     "eslint-plugin-babel": "^3.1.0",
     "eslint-plugin-react": "^4.2.3",
     "eventsource-polyfill": "^0.9.6",
@@ -65,7 +65,7 @@
     "nodemon": "^1.9.1",
     "redbox-react": "^1.2.2",
     "webpack": "^1.12.14",
-    "webpack-dev-middleware": "^1.5.1",
+    "webpack-dev-middleware": "^1.6.1",
     "webpack-hot-middleware": "^2.10.0"
   }
 }


### PR DESCRIPTION
Be aware particularly of the jump of babel-eslint from 5.0.0 to 6.0.0, everything else is minor or patch updates.
